### PR TITLE
Allow sinon peerDep to allow minor versions above 4.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "sinon": "4.1.3"
+    "sinon": "^4.1.3"
   },
   "devDependencies": {
     "babel-cli": "6.2.0",


### PR DESCRIPTION
Resolves #8 