### PR TITLE
Add .write() as a stub to the Response object. Hotfix/2.0.3

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,6 +59,7 @@ var mockRes = exports.mockRes = function mockRes() {
     set: _sinon2.default.stub().returns(ret),
     status: _sinon2.default.stub().returns(ret),
     type: _sinon2.default.stub().returns(ret),
-    vary: _sinon2.default.stub().returns(ret)
+    vary: _sinon2.default.stub().returns(ret),
+    write: _sinon2.default.stub().returns(ret)
   }, options);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sinon-express-mock",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sinon-express-mock",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Simple request and response mock objects to pass into Express routes when testing using Sinon.",
   "main": "lib/index.js",
   "directories": {

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,10 @@ describe('my route', () => {
 
 ## Changelog
 
+### v2.0.3
+
+* `res.write()` is now stubbed.
+
 ### v2.0.0
 
 * Make sinon a `peerDependency`.

--- a/src/index.js
+++ b/src/index.js
@@ -45,5 +45,6 @@ export const mockRes = (options = {}) => {
     status: sinon.stub().returns(ret),
     type: sinon.stub().returns(ret),
     vary: sinon.stub().returns(ret),
+    write: sinon.stub().returns(ret),
   }, options)
 }


### PR DESCRIPTION
Hi, Dana

I've been using your module for some time and I love it! I noticed that **res.write()** didn't exist on the response object so I created a pull request for it.

I'm looking forward to your response!

Craig