### PR TITLE
Add stub writeHead to mockRes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -60,6 +60,7 @@ var mockRes = exports.mockRes = function mockRes() {
     status: _sinon2.default.stub().returns(ret),
     type: _sinon2.default.stub().returns(ret),
     vary: _sinon2.default.stub().returns(ret),
-    write: _sinon2.default.stub().returns(ret)
+    write: _sinon2.default.stub().returns(ret),
+    writeHead: _sinon2.default.stub().returns(ret)
   }, options);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -46,5 +46,6 @@ export const mockRes = (options = {}) => {
     type: sinon.stub().returns(ret),
     vary: sinon.stub().returns(ret),
     write: sinon.stub().returns(ret),
+    writeHead: sinon.stub().returns(ret),
   }, options)
 }


### PR DESCRIPTION
Just found this module and it made my day so much better! Thanks for implementing it. I found that there was no stub for `res.writeHead` so I took the liberty to add it.

[EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource)s usually require a keep-alive header where only the head is sent initially. Example:

```JavaScript
res.writeHead(200, {
  'Content-Type': 'text/event-stream',
  'Cache-Control': 'no-cache',
  'Connection': 'keep-alive'
});
```