### PR TITLE
Add header to mockReq

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,7 @@ var mockReq = exports.mockReq = function mockReq() {
     body: {},
     flash: _sinon2.default.stub().returns(ret),
     get: _sinon2.default.stub().returns(ret),
+    header: _sinon2.default.stub().returns(ret),
     is: _sinon2.default.stub().returns(ret),
     params: {},
     query: {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,22 +4,64 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/commons": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
+      "integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "asynckit": {
@@ -40,26 +82,26 @@
       "integrity": "sha1-cDBpHL3cr+LR3WlofW+M4VJ0jIo=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-polyfill": "6.26.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "5.8.38",
-        "bin-version-check": "2.1.0",
+        "babel-core": "^6.2.0",
+        "babel-polyfill": "^6.2.0",
+        "babel-register": "^6.2.0",
+        "babel-runtime": "^5.0.0",
+        "bin-version-check": "^2.1.0",
         "chalk": "1.1.1",
-        "chokidar": "1.7.0",
-        "commander": "2.12.2",
-        "convert-source-map": "1.5.1",
-        "fs-readdir-recursive": "0.1.2",
-        "glob": "5.0.15",
-        "lodash": "3.10.1",
-        "log-symbols": "1.0.2",
-        "output-file-sync": "1.1.2",
-        "path-exists": "1.0.0",
-        "path-is-absolute": "1.0.1",
-        "request": "2.83.0",
-        "slash": "1.0.0",
-        "source-map": "0.5.7",
-        "v8flags": "2.1.1"
+        "chokidar": "^1.0.0",
+        "commander": "^2.8.1",
+        "convert-source-map": "^1.1.0",
+        "fs-readdir-recursive": "^0.1.0",
+        "glob": "^5.0.5",
+        "lodash": "^3.2.0",
+        "log-symbols": "^1.0.2",
+        "output-file-sync": "^1.1.0",
+        "path-exists": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "request": "^2.65.0",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.0",
+        "v8flags": "^2.0.10"
       },
       "dependencies": {
         "ansi-regex": {
@@ -80,8 +122,8 @@
           "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
           "dev": true,
           "requires": {
-            "micromatch": "2.3.11",
-            "normalize-path": "2.1.1"
+            "micromatch": "^2.1.5",
+            "normalize-path": "^2.0.0"
           }
         },
         "arr-diff": {
@@ -90,7 +132,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0"
+            "arr-flatten": "^1.0.1"
           }
         },
         "arr-flatten": {
@@ -141,9 +183,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           },
           "dependencies": {
             "chalk": {
@@ -152,11 +194,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               }
             }
           }
@@ -167,25 +209,25 @@
           "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-generator": "6.26.0",
-            "babel-helpers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-register": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "convert-source-map": "1.5.1",
-            "debug": "2.6.9",
-            "json5": "0.5.1",
-            "lodash": "4.17.4",
-            "minimatch": "3.0.4",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.8",
-            "slash": "1.0.0",
-            "source-map": "0.5.7"
+            "babel-code-frame": "^6.26.0",
+            "babel-generator": "^6.26.0",
+            "babel-helpers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-register": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "convert-source-map": "^1.5.0",
+            "debug": "^2.6.8",
+            "json5": "^0.5.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.4",
+            "path-is-absolute": "^1.0.1",
+            "private": "^0.1.7",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.6"
           },
           "dependencies": {
             "babel-runtime": {
@@ -194,8 +236,8 @@
               "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
               "dev": true,
               "requires": {
-                "core-js": "2.5.3",
-                "regenerator-runtime": "0.11.1"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
               }
             },
             "lodash": {
@@ -212,14 +254,14 @@
           "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
           "dev": true,
           "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.4",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.6",
+            "trim-right": "^1.0.1"
           },
           "dependencies": {
             "babel-runtime": {
@@ -228,8 +270,8 @@
               "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
               "dev": true,
               "requires": {
-                "core-js": "2.5.3",
-                "regenerator-runtime": "0.11.1"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
               }
             },
             "lodash": {
@@ -246,8 +288,8 @@
           "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           },
           "dependencies": {
             "babel-runtime": {
@@ -256,8 +298,8 @@
               "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
               "dev": true,
               "requires": {
-                "core-js": "2.5.3",
-                "regenerator-runtime": "0.11.1"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
               }
             }
           }
@@ -268,7 +310,7 @@
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           },
           "dependencies": {
             "babel-runtime": {
@@ -277,8 +319,8 @@
               "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
               "dev": true,
               "requires": {
-                "core-js": "2.5.3",
-                "regenerator-runtime": "0.11.1"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
               }
             }
           }
@@ -289,9 +331,9 @@
           "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "core-js": "2.5.3",
-            "regenerator-runtime": "0.10.5"
+            "babel-runtime": "^6.26.0",
+            "core-js": "^2.5.0",
+            "regenerator-runtime": "^0.10.5"
           },
           "dependencies": {
             "babel-runtime": {
@@ -300,8 +342,8 @@
               "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
               "dev": true,
               "requires": {
-                "core-js": "2.5.3",
-                "regenerator-runtime": "0.11.1"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
               },
               "dependencies": {
                 "regenerator-runtime": {
@@ -326,13 +368,13 @@
           "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
           "dev": true,
           "requires": {
-            "babel-core": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "core-js": "2.5.3",
-            "home-or-tmp": "2.0.0",
-            "lodash": "4.17.4",
-            "mkdirp": "0.5.1",
-            "source-map-support": "0.4.18"
+            "babel-core": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "core-js": "^2.5.0",
+            "home-or-tmp": "^2.0.0",
+            "lodash": "^4.17.4",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.4.15"
           },
           "dependencies": {
             "babel-runtime": {
@@ -341,8 +383,8 @@
               "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
               "dev": true,
               "requires": {
-                "core-js": "2.5.3",
-                "regenerator-runtime": "0.11.1"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
               }
             },
             "lodash": {
@@ -359,7 +401,7 @@
           "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
           "dev": true,
           "requires": {
-            "core-js": "1.2.7"
+            "core-js": "^1.0.0"
           },
           "dependencies": {
             "core-js": {
@@ -376,11 +418,11 @@
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           },
           "dependencies": {
             "babel-runtime": {
@@ -389,8 +431,8 @@
               "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
               "dev": true,
               "requires": {
-                "core-js": "2.5.3",
-                "regenerator-runtime": "0.11.1"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
               }
             },
             "lodash": {
@@ -407,15 +449,15 @@
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           },
           "dependencies": {
             "babel-runtime": {
@@ -424,8 +466,8 @@
               "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
               "dev": true,
               "requires": {
-                "core-js": "2.5.3",
-                "regenerator-runtime": "0.11.1"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
               }
             },
             "lodash": {
@@ -442,10 +484,10 @@
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           },
           "dependencies": {
             "babel-runtime": {
@@ -454,8 +496,8 @@
               "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
               "dev": true,
               "requires": {
-                "core-js": "2.5.3",
-                "regenerator-runtime": "0.11.1"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
               }
             },
             "lodash": {
@@ -484,7 +526,7 @@
           "integrity": "sha1-nrSY7m/Xb3q5p8FgQ2+JV5Q1144=",
           "dev": true,
           "requires": {
-            "find-versions": "1.2.1"
+            "find-versions": "^1.0.0"
           }
         },
         "bin-version-check": {
@@ -493,10 +535,10 @@
           "integrity": "sha1-5OXfKQuQaffRETJAMe/BP90RpbA=",
           "dev": true,
           "requires": {
-            "bin-version": "1.0.4",
-            "minimist": "1.2.0",
-            "semver": "4.3.6",
-            "semver-truncate": "1.1.2"
+            "bin-version": "^1.0.0",
+            "minimist": "^1.1.0",
+            "semver": "^4.0.3",
+            "semver-truncate": "^1.0.0"
           },
           "dependencies": {
             "minimist": {
@@ -519,7 +561,7 @@
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         },
         "brace-expansion": {
@@ -528,7 +570,7 @@
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -538,9 +580,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "builtin-modules": {
@@ -561,8 +603,8 @@
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
           }
         },
         "caseless": {
@@ -577,11 +619,11 @@
           "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.1.0",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "chokidar": {
@@ -590,15 +632,15 @@
           "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
           "dev": true,
           "requires": {
-            "anymatch": "1.3.2",
-            "async-each": "1.0.1",
-            "fsevents": "1.1.3",
-            "glob-parent": "2.0.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "2.0.1",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.1.0"
+            "anymatch": "^1.3.0",
+            "async-each": "^1.0.0",
+            "fsevents": "^1.0.0",
+            "glob-parent": "^2.0.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^2.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0"
           }
         },
         "combined-stream": {
@@ -607,7 +649,7 @@
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "commander": {
@@ -646,7 +688,7 @@
           "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
           "dev": true,
           "requires": {
-            "boom": "5.2.0"
+            "boom": "5.x.x"
           },
           "dependencies": {
             "boom": {
@@ -655,7 +697,7 @@
               "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
               "dev": true,
               "requires": {
-                "hoek": "4.2.0"
+                "hoek": "4.x.x"
               }
             }
           }
@@ -666,7 +708,7 @@
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "debug": {
@@ -690,7 +732,7 @@
           "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "ecc-jsbn": {
@@ -700,7 +742,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "error-ex": {
@@ -709,7 +751,7 @@
           "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
           "dev": true,
           "requires": {
-            "is-arrayish": "0.2.1"
+            "is-arrayish": "^0.2.1"
           }
         },
         "escape-string-regexp": {
@@ -730,7 +772,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "expand-range": {
@@ -739,7 +781,7 @@
           "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
           "dev": true,
           "requires": {
-            "fill-range": "2.2.3"
+            "fill-range": "^2.1.0"
           }
         },
         "extend": {
@@ -754,7 +796,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "extsprintf": {
@@ -775,11 +817,11 @@
           "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^1.1.3",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "find-up": {
@@ -788,8 +830,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           },
           "dependencies": {
             "path-exists": {
@@ -798,7 +840,7 @@
               "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
               "dev": true,
               "requires": {
-                "pinkie-promise": "2.0.1"
+                "pinkie-promise": "^2.0.0"
               }
             }
           }
@@ -809,10 +851,10 @@
           "integrity": "sha1-y96fEuOFdaCvG+G5osXV/Y8Ya2I=",
           "dev": true,
           "requires": {
-            "array-uniq": "1.0.3",
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0",
-            "semver-regex": "1.0.0"
+            "array-uniq": "^1.0.0",
+            "get-stdin": "^4.0.1",
+            "meow": "^3.5.0",
+            "semver-regex": "^1.0.0"
           }
         },
         "for-in": {
@@ -827,7 +869,7 @@
           "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
           "dev": true,
           "requires": {
-            "for-in": "1.0.2"
+            "for-in": "^1.0.1"
           }
         },
         "forever-agent": {
@@ -842,9 +884,9 @@
           "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs-readdir-recursive": {
@@ -860,8 +902,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "nan": "2.8.0",
-            "node-pre-gyp": "0.6.39"
+            "nan": "^2.3.0",
+            "node-pre-gyp": "^0.6.39"
           },
           "dependencies": {
             "abbrev": {
@@ -876,8 +918,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
+                "co": "^4.6.0",
+                "json-stable-stringify": "^1.0.1"
               }
             },
             "ansi-regex": {
@@ -897,8 +939,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.2.9"
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
               }
             },
             "asn1": {
@@ -942,7 +984,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
               }
             },
             "block-stream": {
@@ -950,7 +992,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
               }
             },
             "boom": {
@@ -958,7 +1000,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
               }
             },
             "brace-expansion": {
@@ -966,7 +1008,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "balanced-match": "0.4.2",
+                "balanced-match": "^0.4.1",
                 "concat-map": "0.0.1"
               }
             },
@@ -997,7 +1039,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
               }
             },
             "concat-map": {
@@ -1020,7 +1062,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "boom": "2.10.1"
+                "boom": "2.x.x"
               }
             },
             "dashdash": {
@@ -1029,7 +1071,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -1078,7 +1120,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
               }
             },
             "extend": {
@@ -1104,9 +1146,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.15"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
               }
             },
             "fs.realpath": {
@@ -1119,10 +1161,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.1"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
               }
             },
             "fstream-ignore": {
@@ -1131,9 +1173,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "fstream": "1.0.11",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4"
+                "fstream": "^1.0.0",
+                "inherits": "2",
+                "minimatch": "^3.0.0"
               }
             },
             "gauge": {
@@ -1142,14 +1184,14 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "aproba": "1.1.1",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
               }
             },
             "getpass": {
@@ -1158,7 +1200,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -1174,12 +1216,12 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "graceful-fs": {
@@ -1199,8 +1241,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
+                "ajv": "^4.9.1",
+                "har-schema": "^1.0.5"
               }
             },
             "has-unicode": {
@@ -1214,10 +1256,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
               }
             },
             "hoek": {
@@ -1231,9 +1273,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.0",
-                "sshpk": "1.13.0"
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
               }
             },
             "inflight": {
@@ -1241,8 +1283,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
               }
             },
             "inherits": {
@@ -1261,7 +1303,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "is-typedarray": {
@@ -1287,7 +1329,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
               }
             },
             "jsbn": {
@@ -1308,7 +1350,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
               }
             },
             "json-stringify-safe": {
@@ -1353,7 +1395,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "mime-db": "1.27.0"
+                "mime-db": "~1.27.0"
               }
             },
             "minimatch": {
@@ -1361,7 +1403,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.7"
+                "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
@@ -1389,17 +1431,17 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "detect-libc": "1.0.2",
+                "detect-libc": "^1.0.2",
                 "hawk": "3.1.3",
-                "mkdirp": "0.5.1",
-                "nopt": "4.0.1",
-                "npmlog": "4.1.0",
-                "rc": "1.2.1",
+                "mkdirp": "^0.5.1",
+                "nopt": "^4.0.1",
+                "npmlog": "^4.0.2",
+                "rc": "^1.1.7",
                 "request": "2.81.0",
-                "rimraf": "2.6.1",
-                "semver": "5.3.0",
-                "tar": "2.2.1",
-                "tar-pack": "3.4.0"
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^2.2.1",
+                "tar-pack": "^3.4.0"
               }
             },
             "nopt": {
@@ -1408,8 +1450,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "abbrev": "1.1.0",
-                "osenv": "0.1.4"
+                "abbrev": "1",
+                "osenv": "^0.1.4"
               }
             },
             "npmlog": {
@@ -1418,10 +1460,10 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "are-we-there-yet": "1.1.4",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
               }
             },
             "number-is-nan": {
@@ -1446,7 +1488,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               }
             },
             "os-homedir": {
@@ -1467,8 +1509,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
               }
             },
             "path-is-absolute": {
@@ -1505,10 +1547,10 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "deep-extend": "0.4.2",
-                "ini": "1.3.4",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "~0.4.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
               },
               "dependencies": {
                 "minimist": {
@@ -1524,13 +1566,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "buffer-shims": "1.0.0",
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "string_decoder": "1.0.1",
-                "util-deprecate": "1.0.2"
+                "buffer-shims": "~1.0.0",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~1.0.0",
+                "util-deprecate": "~1.0.1"
               }
             },
             "request": {
@@ -1539,28 +1581,28 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.15",
-                "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
-                "safe-buffer": "5.0.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.2",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.0.1"
+                "aws-sign2": "~0.6.0",
+                "aws4": "^1.2.1",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.1.1",
+                "har-validator": "~4.2.1",
+                "hawk": "~3.1.3",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "oauth-sign": "~0.8.1",
+                "performance-now": "^0.2.0",
+                "qs": "~6.4.0",
+                "safe-buffer": "^5.0.1",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.3.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.0.0"
               }
             },
             "rimraf": {
@@ -1568,7 +1610,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
               }
             },
             "safe-buffer": {
@@ -1599,7 +1641,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
               }
             },
             "sshpk": {
@@ -1608,15 +1650,15 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jodid25519": "1.0.2",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jodid25519": "^1.0.0",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -1632,9 +1674,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             },
             "string_decoder": {
@@ -1642,7 +1684,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.0.1"
+                "safe-buffer": "^5.0.1"
               }
             },
             "stringstream": {
@@ -1656,7 +1698,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               }
             },
             "strip-json-comments": {
@@ -1670,9 +1712,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
               }
             },
             "tar-pack": {
@@ -1681,14 +1723,14 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "debug": "2.6.8",
-                "fstream": "1.0.11",
-                "fstream-ignore": "1.0.5",
-                "once": "1.4.0",
-                "readable-stream": "2.2.9",
-                "rimraf": "2.6.1",
-                "tar": "2.2.1",
-                "uid-number": "0.0.6"
+                "debug": "^2.2.0",
+                "fstream": "^1.0.10",
+                "fstream-ignore": "^1.0.5",
+                "once": "^1.3.3",
+                "readable-stream": "^2.1.4",
+                "rimraf": "^2.5.1",
+                "tar": "^2.2.1",
+                "uid-number": "^0.0.6"
               }
             },
             "tough-cookie": {
@@ -1697,7 +1739,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
               }
             },
             "tunnel-agent": {
@@ -1706,7 +1748,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "safe-buffer": "5.0.1"
+                "safe-buffer": "^5.0.1"
               }
             },
             "tweetnacl": {
@@ -1747,7 +1789,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "string-width": "1.0.2"
+                "string-width": "^1.0.2"
               }
             },
             "wrappy": {
@@ -1769,11 +1811,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "glob-base": {
@@ -1782,8 +1824,8 @@
           "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
           "dev": true,
           "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
           }
         },
         "glob-parent": {
@@ -1792,7 +1834,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "globals": {
@@ -1813,8 +1855,8 @@
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "dev": true,
           "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
           }
         },
         "has-ansi": {
@@ -1823,7 +1865,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "hawk": {
@@ -1832,10 +1874,10 @@
           "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
           "dev": true,
           "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.1.0"
+            "boom": "4.x.x",
+            "cryptiles": "3.x.x",
+            "hoek": "4.x.x",
+            "sntp": "2.x.x"
           }
         },
         "hoek": {
@@ -1850,8 +1892,8 @@
           "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.1"
           }
         },
         "hosted-git-info": {
@@ -1866,9 +1908,9 @@
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "indent-string": {
@@ -1877,7 +1919,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "inflight": {
@@ -1886,8 +1928,8 @@
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -1902,7 +1944,7 @@
           "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "dev": true,
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "is-arrayish": {
@@ -1917,7 +1959,7 @@
           "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
           "dev": true,
           "requires": {
-            "binary-extensions": "1.11.0"
+            "binary-extensions": "^1.0.0"
           }
         },
         "is-buffer": {
@@ -1932,7 +1974,7 @@
           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "dev": true,
           "requires": {
-            "builtin-modules": "1.1.1"
+            "builtin-modules": "^1.0.0"
           }
         },
         "is-dotfile": {
@@ -1947,7 +1989,7 @@
           "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
           "dev": true,
           "requires": {
-            "is-primitive": "2.0.0"
+            "is-primitive": "^2.0.0"
           }
         },
         "is-extendable": {
@@ -1968,7 +2010,7 @@
           "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-glob": {
@@ -1977,7 +2019,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "is-number": {
@@ -1986,7 +2028,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-primitive": {
@@ -2083,7 +2125,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "load-json-file": {
@@ -2092,11 +2134,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "lodash": {
@@ -2111,7 +2153,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.1"
+            "chalk": "^1.0.0"
           }
         },
         "loose-envify": {
@@ -2120,7 +2162,7 @@
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "loud-rejection": {
@@ -2129,8 +2171,8 @@
           "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
           "dev": true,
           "requires": {
-            "currently-unhandled": "0.4.1",
-            "signal-exit": "3.0.2"
+            "currently-unhandled": "^0.4.1",
+            "signal-exit": "^3.0.0"
           }
         },
         "map-obj": {
@@ -2145,16 +2187,16 @@
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
           },
           "dependencies": {
             "minimist": {
@@ -2171,19 +2213,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         },
         "mime-db": {
@@ -2198,7 +2240,7 @@
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "dev": true,
           "requires": {
-            "mime-db": "1.30.0"
+            "mime-db": "~1.30.0"
           }
         },
         "minimatch": {
@@ -2207,7 +2249,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -2244,10 +2286,10 @@
           "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "4.3.6",
-            "validate-npm-package-license": "3.0.1"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "normalize-path": {
@@ -2256,7 +2298,7 @@
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "1.1.0"
+            "remove-trailing-separator": "^1.0.1"
           }
         },
         "number-is-nan": {
@@ -2283,8 +2325,8 @@
           "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
           "dev": true,
           "requires": {
-            "for-own": "0.1.5",
-            "is-extendable": "0.1.1"
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
           }
         },
         "once": {
@@ -2293,7 +2335,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-tmpdir": {
@@ -2308,9 +2350,9 @@
           "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.1"
+            "graceful-fs": "^4.1.4",
+            "mkdirp": "^0.5.1",
+            "object-assign": "^4.1.0"
           }
         },
         "parse-glob": {
@@ -2319,10 +2361,10 @@
           "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
           "dev": true,
           "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.3",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
           }
         },
         "parse-json": {
@@ -2331,7 +2373,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {
@@ -2352,9 +2394,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -2375,7 +2417,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "preserve": {
@@ -2408,8 +2450,8 @@
           "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
           "dev": true,
           "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -2418,7 +2460,7 @@
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -2427,7 +2469,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -2438,7 +2480,7 @@
               "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -2449,9 +2491,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -2460,8 +2502,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "readable-stream": {
@@ -2470,13 +2512,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "readdirp": {
@@ -2485,10 +2527,10 @@
           "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "minimatch": "3.0.4",
-            "readable-stream": "2.3.3",
-            "set-immediate-shim": "1.0.1"
+            "graceful-fs": "^4.1.2",
+            "minimatch": "^3.0.2",
+            "readable-stream": "^2.0.2",
+            "set-immediate-shim": "^1.0.1"
           }
         },
         "redent": {
@@ -2497,8 +2539,8 @@
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "dev": true,
           "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
           }
         },
         "regex-cache": {
@@ -2507,7 +2549,7 @@
           "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
           "dev": true,
           "requires": {
-            "is-equal-shallow": "0.1.3"
+            "is-equal-shallow": "^0.1.3"
           }
         },
         "repeat-element": {
@@ -2528,7 +2570,7 @@
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         },
         "request": {
@@ -2537,28 +2579,28 @@
           "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "stringstream": "~0.0.5",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
           }
         },
         "semver": {
@@ -2579,7 +2621,7 @@
           "integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
           "dev": true,
           "requires": {
-            "semver": "5.4.1"
+            "semver": "^5.3.0"
           },
           "dependencies": {
             "semver": {
@@ -2608,7 +2650,7 @@
           "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         },
         "source-map": {
@@ -2623,7 +2665,7 @@
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7"
+            "source-map": "^0.5.6"
           }
         },
         "spdx-correct": {
@@ -2632,7 +2674,7 @@
           "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
           "dev": true,
           "requires": {
-            "spdx-license-ids": "1.2.2"
+            "spdx-license-ids": "^1.0.2"
           }
         },
         "spdx-expression-parse": {
@@ -2653,14 +2695,14 @@
           "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
           "dev": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
           }
         },
         "string_decoder": {
@@ -2669,7 +2711,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "stringstream": {
@@ -2684,7 +2726,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -2693,7 +2735,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-indent": {
@@ -2702,7 +2744,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1"
+            "get-stdin": "^4.0.1"
           }
         },
         "supports-color": {
@@ -2723,7 +2765,7 @@
           "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
           "dev": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "trim-newlines": {
@@ -2744,7 +2786,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -2772,7 +2814,7 @@
           "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
           "dev": true,
           "requires": {
-            "user-home": "1.1.1"
+            "user-home": "^1.1.1"
           }
         },
         "validate-npm-package-license": {
@@ -2781,8 +2823,8 @@
           "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
           "dev": true,
           "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
+            "spdx-correct": "~1.0.0",
+            "spdx-expression-parse": "~1.0.0"
           }
         },
         "verror": {
@@ -2791,9 +2833,9 @@
           "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
+            "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
+            "extsprintf": "^1.2.0"
           }
         },
         "wrappy": {
@@ -2810,26 +2852,26 @@
       "integrity": "sha1-W4+XrNnlDLxMTiTqsS1bGrx0zdo=",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0"
+        "babel-plugin-check-es2015-constants": "^6.1.18",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.1.18",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.1.18",
+        "babel-plugin-transform-es2015-block-scoping": "^6.1.18",
+        "babel-plugin-transform-es2015-classes": "^6.1.18",
+        "babel-plugin-transform-es2015-computed-properties": "^6.1.18",
+        "babel-plugin-transform-es2015-destructuring": "^6.1.18",
+        "babel-plugin-transform-es2015-for-of": "^6.1.18",
+        "babel-plugin-transform-es2015-function-name": "^6.1.18",
+        "babel-plugin-transform-es2015-literals": "^6.1.18",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.1.18",
+        "babel-plugin-transform-es2015-object-super": "^6.1.18",
+        "babel-plugin-transform-es2015-parameters": "^6.1.18",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.1.18",
+        "babel-plugin-transform-es2015-spread": "^6.1.18",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.1.18",
+        "babel-plugin-transform-es2015-template-literals": "^6.1.18",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.1.18",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.1.18",
+        "babel-plugin-transform-regenerator": "^6.1.18"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2850,9 +2892,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "babel-helper-call-delegate": {
@@ -2861,10 +2903,10 @@
           "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
           "dev": true,
           "requires": {
-            "babel-helper-hoist-variables": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-hoist-variables": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-define-map": {
@@ -2873,10 +2915,10 @@
           "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
           "dev": true,
           "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.4"
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-helper-function-name": {
@@ -2885,11 +2927,11 @@
           "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
           "dev": true,
           "requires": {
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-get-function-arity": {
@@ -2898,8 +2940,8 @@
           "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-hoist-variables": {
@@ -2908,8 +2950,8 @@
           "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-optimise-call-expression": {
@@ -2918,8 +2960,8 @@
           "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-regex": {
@@ -2928,9 +2970,9 @@
           "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-helper-replace-supers": {
@@ -2939,12 +2981,12 @@
           "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
           "dev": true,
           "requires": {
-            "babel-helper-optimise-call-expression": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-optimise-call-expression": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-messages": {
@@ -2953,7 +2995,7 @@
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-check-es2015-constants": {
@@ -2962,7 +3004,7 @@
           "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-arrow-functions": {
@@ -2971,7 +3013,7 @@
           "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -2980,7 +3022,7 @@
           "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-block-scoping": {
@@ -2989,11 +3031,11 @@
           "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-plugin-transform-es2015-classes": {
@@ -3002,15 +3044,15 @@
           "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
           "dev": true,
           "requires": {
-            "babel-helper-define-map": "6.26.0",
-            "babel-helper-function-name": "6.24.1",
-            "babel-helper-optimise-call-expression": "6.24.1",
-            "babel-helper-replace-supers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-define-map": "^6.24.1",
+            "babel-helper-function-name": "^6.24.1",
+            "babel-helper-optimise-call-expression": "^6.24.1",
+            "babel-helper-replace-supers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-computed-properties": {
@@ -3019,8 +3061,8 @@
           "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-destructuring": {
@@ -3029,7 +3071,7 @@
           "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-for-of": {
@@ -3038,7 +3080,7 @@
           "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-function-name": {
@@ -3047,9 +3089,9 @@
           "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
           "dev": true,
           "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-literals": {
@@ -3058,7 +3100,7 @@
           "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
@@ -3067,10 +3109,10 @@
           "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
           "dev": true,
           "requires": {
-            "babel-plugin-transform-strict-mode": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-plugin-transform-strict-mode": "^6.24.1",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-types": "^6.26.0"
           }
         },
         "babel-plugin-transform-es2015-object-super": {
@@ -3079,8 +3121,8 @@
           "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
           "dev": true,
           "requires": {
-            "babel-helper-replace-supers": "6.24.1",
-            "babel-runtime": "6.26.0"
+            "babel-helper-replace-supers": "^6.24.1",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-parameters": {
@@ -3089,12 +3131,12 @@
           "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
           "dev": true,
           "requires": {
-            "babel-helper-call-delegate": "6.24.1",
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-call-delegate": "^6.24.1",
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
@@ -3103,8 +3145,8 @@
           "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-spread": {
@@ -3113,7 +3155,7 @@
           "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-sticky-regex": {
@@ -3122,9 +3164,9 @@
           "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
           "dev": true,
           "requires": {
-            "babel-helper-regex": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-regex": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-template-literals": {
@@ -3133,7 +3175,7 @@
           "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-typeof-symbol": {
@@ -3142,7 +3184,7 @@
           "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-unicode-regex": {
@@ -3151,9 +3193,9 @@
           "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
           "dev": true,
           "requires": {
-            "babel-helper-regex": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "regexpu-core": "2.0.0"
+            "babel-helper-regex": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "regexpu-core": "^2.0.0"
           }
         },
         "babel-plugin-transform-regenerator": {
@@ -3162,7 +3204,7 @@
           "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
           "dev": true,
           "requires": {
-            "regenerator-transform": "0.10.1"
+            "regenerator-transform": "^0.10.0"
           }
         },
         "babel-plugin-transform-strict-mode": {
@@ -3171,8 +3213,8 @@
           "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-runtime": {
@@ -3181,8 +3223,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.3",
-            "regenerator-runtime": "0.11.1"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
           }
         },
         "babel-template": {
@@ -3191,11 +3233,11 @@
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-traverse": {
@@ -3204,15 +3246,15 @@
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           }
         },
         "babel-types": {
@@ -3221,10 +3263,10 @@
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "babylon": {
@@ -3239,11 +3281,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "core-js": {
@@ -3285,7 +3327,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "invariant": {
@@ -3294,7 +3336,7 @@
           "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "dev": true,
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "js-tokens": {
@@ -3315,7 +3357,7 @@
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "ms": {
@@ -3330,7 +3372,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -3354,7 +3396,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       },
       "dependencies": {
         "tweetnacl": {
@@ -3378,13 +3420,19 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "fast-deep-equal": {
@@ -3405,7 +3453,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -3422,10 +3470,22 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
     "json-schema-traverse": {
@@ -3434,11 +3494,59 @@
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "lolex": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.1.0.tgz",
+      "integrity": "sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==",
+      "dev": true
+    },
+    "nise": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.10.tgz",
+      "integrity": "sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "dev": true
+        }
+      }
+    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
     },
     "performance-now": {
       "version": "2.1.0",
@@ -3464,9 +3572,9 @@
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       },
       "dependencies": {
         "babel-runtime": {
@@ -3475,8 +3583,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.3",
-            "regenerator-runtime": "0.11.1"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
           }
         },
         "babel-types": {
@@ -3485,10 +3593,10 @@
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "core-js": {
@@ -3529,9 +3637,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       },
       "dependencies": {
         "jsesc": {
@@ -3558,7 +3666,7 @@
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "dev": true,
           "requires": {
-            "jsesc": "0.5.0"
+            "jsesc": "~0.5.0"
           }
         }
       }
@@ -3579,6 +3687,36 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "dev": true
+    },
+    "sinon": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.1.tgz",
+      "integrity": "sha512-eQKMaeWovtOtYe2xThEvaHmmxf870Di+bim10c3ZPrL5bZhLGtu8cz+rOBTFz0CwBV4Q/7dYwZiqZbGVLZ+vjQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.1",
+        "diff": "^3.5.0",
+        "lolex": "^3.1.0",
+        "nise": "^1.4.10",
+        "supports-color": "^5.5.0"
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "uuid": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "babel-cli": "6.2.0",
-    "babel-preset-es2015": "6.1.18"
+    "babel-preset-es2015": "6.1.18",
+    "sinon": "*"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ export const mockReq = (options = {}) => {
     body: {},
     flash: sinon.stub().returns(ret),
     get: sinon.stub().returns(ret),
+    header: sinon.stub().returns(ret),
     is: sinon.stub().returns(ret),
     params: {},
     query: {},


### PR DESCRIPTION
1. Adds `req.header` to `mockReq()` - as this alias is officially supported in the [express documentation](http://expressjs.com/en/api.html#req.get), it should be supported by the mock.

2. This PR also adds sinon to `devDependencies`, which makes it easier to work with the package while developing.