### PR TITLE
Persist mutations to res.locals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,6 @@ export const mockRes = (options = {}) => {
     json: sinon.stub().returns(ret),
     jsonp: sinon.stub().returns(ret),
     links: sinon.stub().returns(ret),
-    locals: {},
     location: sinon.stub().returns(ret),
     redirect: sinon.stub().returns(ret),
     render: sinon.stub().returns(ret),
@@ -47,5 +46,7 @@ export const mockRes = (options = {}) => {
     vary: sinon.stub().returns(ret),
     write: sinon.stub().returns(ret),
     writeHead: sinon.stub().returns(ret),
-  }, options)
+  },
+  options,
+  { locals: new Object(options.locals || {}) })
 }


### PR DESCRIPTION
Adds persistence to res.locals by using Object constructor syntax rather
than Object literal syntax. This returns an object reference and means
that when passed to a function the reference is updated. As this
reference is avilable outside the middleware being tested it means that
changes to res.locals can be tested.