### PR TITLE
add res.setHeader stub

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ export const mockRes = (options = {}) => {
     sendFile: sinon.stub().returns(ret),
     sendStatus: sinon.stub().returns(ret),
     set: sinon.stub().returns(ret),
+    setHeader: sinon.stub().returns(ret),
     status: sinon.stub().returns(ret),
     type: sinon.stub().returns(ret),
     vary: sinon.stub().returns(ret),


### PR DESCRIPTION
Hi,

I just recognized that `res.setHeaders` is not stubbed on response mock. Is there a reason for it? Would be great, if this will also be included in the library.